### PR TITLE
Use manual observable object publishing to update views on every tick

### DIFF
--- a/NinjaWarriors/ViewModels/CanvasViewModel.swift
+++ b/NinjaWarriors/ViewModels/CanvasViewModel.swift
@@ -10,12 +10,12 @@ import SwiftUI
 
 @MainActor
 final class CanvasViewModel: ObservableObject {
-    @Published var gameWorld: GameWorld
-    @Published private(set) var entities: [Entity] = []
-    @Published private(set) var manager: EntitiesManager
-    @Published private(set) var matchId: String
-    @Published private(set) var currPlayerId: String
-    @Published var positions: [CGPoint]?
+    var gameWorld: GameWorld
+    private(set) var entities: [Entity] = []
+    private(set) var manager: EntitiesManager
+    private(set) var matchId: String
+    private(set) var currPlayerId: String
+    var positions: [CGPoint]?
 
     init(matchId: String, currPlayerId: String) {
         self.matchId = matchId
@@ -41,7 +41,12 @@ final class CanvasViewModel: ObservableObject {
             rigidPositions.append(rigidbody.position.get())
         }
         positions = rigidPositions
+        updateViews()
         await publishData()
+    }
+    
+    func updateViews() {
+        objectWillChange.send()
     }
 
     func addListeners() {


### PR DESCRIPTION
Currently, publishing entities, entityManager, and all positions means that the canvas view is updated for every small change in position. Instead, we should only be updating views for every tick (so every 1/60 seconds). My fix is to publish `objectWillChange.send()` inside ViewModel.updateViewModel(), which is called by the game loop manager.